### PR TITLE
.htaccessでHTTPSリダイレクトができなくなっていたので対策

### DIFF
--- a/wordpress/wp-content/themes/habakiri/header.php
+++ b/wordpress/wp-content/themes/habakiri/header.php
@@ -8,6 +8,11 @@
  * License    : GPLv2 or later
  * License URI: license.txt
  */
+if (empty($_SERVER['HTTPS'])) {
+    header( "HTTP/1.1 301 Moved Permanently" ); 
+    header("Location: https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}");
+    exit;
+}
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>


### PR DESCRIPTION
# ヘッダ情報発行して強制リダイレクト
2017年7月ころは以下の記述でできていたのに何かの変更があったのか適用されなくなっていた。
そのため、リダイレクトをヘッダ情報として出力することによって対策。
以下のサイトを参考にしました。

#### 元の.haccessの内容
```apache
RewriteCond %{HTTPS} off
RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R,L]
```

#### 試してみた.htaccss
```apache
RewriteCond %{HTTPS} off
RewriteCond %{SERVER_PORT} 80
RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R,L]
```

### 参考
- さくらのレンタルサーバで常時SSL化するときに、http→httpsの転送でハマった話 - Qiita  
https://qiita.com/sfp_waterwalker/items/776599cc9158e9d02cec