### PR TITLE
<h1>が複数ある状態を解消させます

### DIFF
--- a/wordpress/wp-content/themes/habakiri/functions.php
+++ b/wordpress/wp-content/themes/habakiri/functions.php
@@ -606,15 +606,15 @@ class Habakiri_Base_Functions {
 		do_action( 'habakiri_before_title' );
 		?>
 		<?php if ( get_query_var( 'is_related' ) ) : ?>
-		<h1 class="entry__title entry-title h4"><a href="<?php the_permalink(); ?>"><?php echo get_the_title( $post_id ); ?></a></h1>
+		<h4 class="entry__title entry-title h4"><a href="<?php the_permalink(); ?>"><?php echo get_the_title( $post_id ); ?></a></h4>
 		<?php elseif ( is_page() ) : ?>
 			<?php if ( !is_page_template( 'templates/front-page.php' ) && !is_page_template( 'templates/rich-front-page.php' ) ) : ?>
 			<h1 class="entry__title"><?php echo get_the_title( $post_id ); ?></h1>
 			<?php endif; ?>
 		<?php elseif ( is_single() ) : ?>
-		<h1 class="entry__title entry-title"><?php echo get_the_title( $post_id ); ?></h1>
+		<h2 class="entry__title entry-title"><?php echo get_the_title( $post_id ); ?></h2>
 		<?php else : ?>
-		<h1 class="entry__title entry-title h3"><a href="<?php the_permalink(); ?>"><?php echo get_the_title( $post_id ); ?></a></h1>
+		<h3 class="entry__title entry-title h3"><a href="<?php the_permalink(); ?>"><?php echo get_the_title( $post_id ); ?></a></h3>
 		<?php endif; ?>
 		<?php
 		do_action( 'habakiri_after_title' );


### PR DESCRIPTION
Bing Webマスターツールで表示された以下の件の解消

> ## SEO 分析の詳細 (ベータ)
> 
> SEO 提案	ページに複数の `<h1>` タグが存在しています。
> 重要度	高
> エラー カウント	37
> 非対応ページ	4
> 推奨される操作	ページ ソースから余分な `<h1>` タグを削除し、1 つの `<h1>` タグしか存在しないようにします。